### PR TITLE
HACK: Fix cursor crash

### DIFF
--- a/hw/xwayland/xwayland-shm.c
+++ b/hw/xwayland/xwayland-shm.c
@@ -259,8 +259,7 @@ xwl_shm_create_pixmap(ScreenPtr screen,
     uint32_t format;
     int fd;
 
-    if (hint != CREATE_PIXMAP_USAGE_GLYPH_PICTURE ||
-        (!xwl_screen->rootless && hint != CREATE_PIXMAP_USAGE_BACKING_PIXMAP) ||
+    if ((!xwl_screen->rootless && hint != CREATE_PIXMAP_USAGE_BACKING_PIXMAP) ||
         (width == 0 && height == 0) || depth < 15)
         return fbCreatePixmap(screen, width, height, depth, hint);
 


### PR DESCRIPTION
UI decorations and mouse pointers are missing across the board, and that
seems to be causing a crash when we try to handle pointer change events.
Remove a check so we at least finish initializing the pointer and can
test without the UI elements.

(EE)
(EE) Backtrace:
(EE) 0: /opt/stable/debug/x86_64/bin/Xwayland (OsSigHandler+0x3b) [0x558e83eaf737]
(EE) 1: /lib/x86_64-linux-gnu/libc.so.6 (killpg+0x40) [0x7f37d061487f]
(EE) 2: /opt/stable/debug/x86_64/bin/Xwayland (xwl_shm_pixmap_get_wl_buffer+0x20) [0x558e83cf8332]
(EE) 3: /opt/stable/debug/x86_64/bin/Xwayland (xwl_seat_set_cursor+0x1de) [0x558e83cf5335]
(EE) 4: /opt/stable/debug/x86_64/bin/Xwayland (xwl_set_cursor+0x82) [0x558e83cf56ff]
(EE) 5: /opt/stable/debug/x86_64/bin/Xwayland (miPointerUpdateSprite+0x261) [0x558e83d55ff1]
(EE) 6: /opt/stable/debug/x86_64/bin/Xwayland (miPointerDisplayCursor+0xae) [0x558e83d5585b]
(EE) 7: /opt/stable/debug/x86_64/bin/Xwayland (CursorDisplayCursor+0xdd) [0x558e83e3a0cf]
(EE) 8: /opt/stable/debug/x86_64/bin/Xwayland (AnimCurDisplayCursor+0x1ba) [0x558e83e0617f]
(EE) 9: /opt/stable/debug/x86_64/bin/Xwayland (ChangeToCursor+0xd6) [0x558e83d8ca48]
(EE) 10: /opt/stable/debug/x86_64/bin/Xwayland (PostNewCursor+0x124) [0x558e83d8cbde]
(EE) 11: /opt/stable/debug/x86_64/bin/Xwayland (CheckMotion+0x394) [0x558e83d9165a]
(EE) 12: /opt/stable/debug/x86_64/bin/Xwayland (pointer_handle_leave+0x92) [0x558e83cefd29]
(EE) 13: /lib/x86_64-linux-gnu/libffi.so.6 (ffi_call_unix64+0x4c) [0x7f37d00928ee]
(EE) 14: /lib/x86_64-linux-gnu/libffi.so.6 (ffi_call+0x22f) [0x7f37d00922bf]
(EE) 15: /opt/stable/debug/x86_64/lib/libwayland-client.so.0 (wl_closure_invoke+0x1ad) [0x7f37d0c5af7d]
(EE) 16: /opt/stable/debug/x86_64/lib/libwayland-client.so.0 (dispatch_event.isra.6+0x139) [0x7f37d0c57a49]
(EE) 17: /opt/stable/debug/x86_64/lib/libwayland-client.so.0 (wl_display_dispatch_queue_pending+0x74) [0x7f37d0c58e44]
(EE) 18: /opt/stable/debug/x86_64/bin/Xwayland (xwl_read_events+0x7d) [0x558e83cf6d13]
(EE) 19: /opt/stable/debug/x86_64/bin/Xwayland (socket_handler+0x26) [0x558e83cf6f03]
(EE) 20: /opt/stable/debug/x86_64/bin/Xwayland (HandleNotifyFd+0x34) [0x558e83ead1e9]
(EE) 21: /opt/stable/debug/x86_64/bin/Xwayland (ospoll_wait+0xdc) [0x558e83eb04de]
(EE) 22: /opt/stable/debug/x86_64/bin/Xwayland (WaitForSomething+0xbc) [0x558e83ea8afe]
(EE) 23: /opt/stable/debug/x86_64/bin/Xwayland (Dispatch+0x53) [0x558e83d78009]
(EE) 24: /opt/stable/debug/x86_64/bin/Xwayland (dix_main+0x5a4) [0x558e83d864c0]
(EE) 25: /opt/stable/debug/x86_64/bin/Xwayland (main+0x28) [0x558e83d04378]
(EE) 26: /lib/x86_64-linux-gnu/libc.so.6 (__libc_start_main+0xeb) [0x7f37d060109b]
(EE) 27: /opt/stable/debug/x86_64/bin/Xwayland (_start+0x2a)
[0x558e83ceda4a]
(EE)
(EE) Segmentation fault at address 0x18
(EE)
Fatal server error:
(EE) Caught signal 11 (Segmentation fault). Server aborting